### PR TITLE
feat: NftOwnershsip.creators and NftItem.owners deprecated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.21.3</revision>
+        <revision>1.21.4</revision>
         <openapi.plugin.version>5.1.0</openapi.plugin.version>
         <rarible.codegen.server.version>1.2.0</rarible.codegen.server.version>
         <rarible.codegen.client.version>1.3.0</rarible.codegen.client.version>

--- a/protocol-model-nft-order/openapi.yaml
+++ b/protocol-model-nft-order/openapi.yaml
@@ -38,7 +38,6 @@ components:
         - creators
         - supply
         - lazySupply
-        - owners
         - royalties
         - date
         - pending
@@ -65,6 +64,7 @@ components:
           $ref: "#/components/schemas/BigInteger"
         owners:
           type: array
+          deprecated: true
           description: Owners of the target items
           items:
             "$ref": "#/components/schemas/Address"
@@ -163,6 +163,7 @@ components:
           $ref: "#/components/schemas/Address"
         creators:
           type: array
+          deprecated: true
           items:
             "$ref": "#/components/schemas/Part"
         value:

--- a/protocol-model-nft/openapi.yaml
+++ b/protocol-model-nft/openapi.yaml
@@ -143,7 +143,6 @@ components:
         - creators
         - supply
         - lazySupply
-        - owners
         - royalties
       type: object
       properties:
@@ -165,6 +164,7 @@ components:
           "$ref": "#/components/schemas/BigInteger"
         owners:
           type: array
+          deprecated: true
           description: Owners of the target items
           items:
             "$ref": "#/components/schemas/Address"
@@ -460,7 +460,6 @@ components:
         - contract
         - tokenId
         - owner
-        - creators
         - value
         - lazyValue
         - date
@@ -478,6 +477,7 @@ components:
           "$ref": "#/components/schemas/Address"
         creators:
           type: array
+          deprecated: true
           description: Creators of the target item
           items:
             "$ref": "#/components/schemas/Part"


### PR DESCRIPTION
feat: NftOwnershsip.creators and NftItem.owners deprecated and not required anymore