### PR TITLE
ALPHA-405 Add dbUpdatedAt to Ethereum for Orders (#39)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.25.2</revision>
+        <revision>1.25.3</revision>
         <openapi.plugin.version>5.1.0</openapi.plugin.version>
         <rarible.codegen.server.version>1.2.0</rarible.codegen.server.version>
         <rarible.codegen.client.version>1.3.0</rarible.codegen.client.version>

--- a/protocol-api-order/openapi.yaml
+++ b/protocol-api-order/openapi.yaml
@@ -1131,6 +1131,41 @@ paths:
         '500':
           $ref: "#/components/responses/ServerError"
 
+  "/v0.1/orders/sync":
+    get:
+      tags:
+        - order-controller
+      description: Returns all orders with dbUpdatedAt sorting
+      operationId: getAllSync
+      parameters:
+        - name: sort
+          description: "Sorting by data base update"
+          in: query
+          required: false
+          schema:
+            "$ref": "#/components/schemas/OrderSyncSort"
+        - name: continuation
+          description: "Continuation token from the previous response"
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: size
+          description: "The number of orders to return"
+          in: query
+          required: false
+          schema:
+            minimum: 1
+            type: integer
+            format: int32
+      responses:
+        '200':
+          $ref: "#/components/responses/OrderPage"
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '500':
+          $ref: "#/components/responses/ServerError"
+
   "/v0.1/orders/all/byStatus":
     get:
       tags:

--- a/protocol-model-order/openapi.yaml
+++ b/protocol-model-order/openapi.yaml
@@ -601,6 +601,9 @@ components:
         lastUpdateAt:
           type: string
           format: date-time
+        dbUpdatedAt:
+          type: string
+          format: date-time
         pending:
           type: array
           items:
@@ -795,6 +798,12 @@ components:
       enum:
         - LAST_UPDATE_ASC
         - LAST_UPDATE_DESC
+
+    OrderSyncSort:
+      type: string
+      enum:
+        - DB_UPDATE_ASC
+        - DB_UPDATE_DESC
 
     OrdersPagination:
       type: object


### PR DESCRIPTION
feat: ALPHA-405 add dbUpdatedAt to Ethereum for Orders

* Added new endpoint - orders/sync
* Added new field dbUpdatedAt
* Added new sort types:
        - DB_UPDATE_ASC
        - DB_UPDATE_DESC